### PR TITLE
Alt attribute button default type should be explicitly set as "button…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umn-latis/quill-better-image-module",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "keywords": [
     "quill",
     "quilljs",

--- a/src/modules/AltText.js
+++ b/src/modules/AltText.js
@@ -13,7 +13,7 @@ export class AltText extends BaseModule {
       <style>
           ${AltTextCSS}
       </style>
-      <button aria-label="Toggle alt text editor" class="ql-alt-text__button">
+      <button type="button" aria-label="Toggle alt text editor" class="ql-alt-text__button">
         <i class="icon" aria-hidden="true" focusable="false">
           ${UniversalAccessIcon}
         </i>
@@ -30,7 +30,7 @@ export class AltText extends BaseModule {
 
     // toggle the alt text editor when the button is clicked
     const toggleEditorButton = this.altText.querySelector(
-      ".ql-alt-text__button"
+      ".ql-alt-text__button",
     );
     toggleEditorButton.addEventListener("click", () => {
       this.altText.classList.toggle("ql-alt-text--is-open");


### PR DESCRIPTION
…" for form use.

Fixes #1